### PR TITLE
Update wall.R

### DIFF
--- a/R/wall.R
+++ b/R/wall.R
@@ -25,7 +25,7 @@
 #' }
 #' @export
 getWall <- function(owner_id='', domain='', offset='', count='', filter='owner', extended='', fields='', v=getAPIVersion()) {
-  .Deprecated("getWall()")
+  .Deprecated("getWallExecute()")
   query <- queryBuilder('wall.get',
                         owner_id = owner_id,
                         domain = domain,


### PR DESCRIPTION
Fix small misbehavior:
=====
Warning message:
'getWall' is deprecated.
Use 'getWall()' instead.